### PR TITLE
Fixes for issues introduced in da96b44f9e25afc593e6b478aaca81ae6220e17e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ TB3 = pulse_gen_controller_tb
 TB4 = interrupt_tb
 
 
-TESTBENCHES = $(TB1) $(TB2) $(TB3) $(TB4) $(TESTBENCHES)
+TESTBENCHES = $(TB1) $(TB2) $(TB3) $(TB4)
 
 # Targets
 .PHONY: all clean opendoc run_sim

--- a/sim/bram_controller_tb/bram_controller_tb_vhdl.prj
+++ b/sim/bram_controller_tb/bram_controller_tb_vhdl.prj
@@ -3,6 +3,7 @@ vhdl xil_defaultlib  \
 
 vhdl work  \
 "../../hdl/packages/sizing.vhd" \
+"../../hdl/packages/register_bank_config_pkg.vhdl" \
 "../../hdl/packages/evr_pkg.vhd" \
 "../../hdl/bram_controller.vhd" \
 "../../hdl/evnt_dec_controller.vhd" \


### PR DESCRIPTION
work.register_bank_config is now required by evr_pkg.vhd. Compile it
into the work library as part of the simulation project.

[ICSHWI-6437]